### PR TITLE
Add backend server and iOS client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.env
+.DS_Store
+.build/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # ora-remote-controller
+
+This repository contains a FastAPI backend and a SwiftUI client to remotely control a Minecraft server and Blender rendering job.
+
+## Backend
+Install requirements and run:
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.main:app --reload
+```
+
+## iOS Client
+Open `ios-client/ORAControl` with Xcode and build.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+API_KEY=changeme
+MC_JAR_PATH=C:\path\to\server.jar
+BLENDER_EXE=C:\Program Files\Blender Foundation\Blender\blender.exe
+BLENDER_OUTPUT_DIR=C:\path\to\output
+FRAME_START=1
+FRAME_END=250

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,68 @@
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from dotenv import load_dotenv
+import os
+from .services import mc, blender
+
+load_dotenv()
+
+API_KEY = os.getenv("API_KEY", "changeme")
+security = HTTPBearer()
+app = FastAPI()
+
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    if credentials.credentials != API_KEY:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+
+@app.get("/status", dependencies=[Depends(verify_token)])
+def status_endpoint():
+    return {
+        "mc_running": mc.is_running(),
+        "render_running": blender.is_running(),
+    }
+
+
+@app.post("/mc/start", dependencies=[Depends(verify_token)])
+def mc_start():
+    if mc.is_running():
+        raise HTTPException(status_code=400, detail="MC already running")
+    mc.start_server()
+    return {"status": "starting"}
+
+
+@app.post("/mc/stop", dependencies=[Depends(verify_token)])
+def mc_stop():
+    if not mc.is_running():
+        raise HTTPException(status_code=400, detail="MC not running")
+    mc.stop_server()
+    return {"status": "stopping"}
+
+
+@app.get("/mc/status", dependencies=[Depends(verify_token)])
+def mc_status():
+    return {"running": mc.is_running()}
+
+
+@app.post("/render/start", dependencies=[Depends(verify_token)])
+def render_start(blend_file: str, frame_start: int = blender.FRAME_START, frame_end: int = blender.FRAME_END):
+    if blender.is_running():
+        raise HTTPException(status_code=400, detail="Render already running")
+    blender.start_render(blend_file, frame_start, frame_end)
+    return {"status": "starting"}
+
+
+@app.post("/render/stop", dependencies=[Depends(verify_token)])
+def render_stop():
+    if not blender.is_running():
+        raise HTTPException(status_code=400, detail="Render not running")
+    blender.stop_render()
+    return {"status": "stopping"}
+
+
+@app.get("/render/status", dependencies=[Depends(verify_token)])
+def render_status():
+    return {"running": blender.is_running()}
+
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+psutil
+python-dotenv
+requests

--- a/backend/run.ps1
+++ b/backend/run.ps1
@@ -1,0 +1,3 @@
+$env:$(Get-Content .env | ForEach-Object {$_})
+uvicorn backend.main:app --host 0.0.0.0 --port 8000
+

--- a/backend/services/blender.py
+++ b/backend/services/blender.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+from ..utils import proc_store
+
+RENDER_KEY = "blender"
+
+BLENDER_EXE = os.getenv("BLENDER_EXE", r"C:\\Program Files\\Blender Foundation\\Blender 4.3\\blender.exe")
+BLENDER_OUTPUT_DIR = os.getenv("BLENDER_OUTPUT_DIR", r"C:\\Users\\YoneRai12\\Renders\\Output")
+FRAME_START = int(os.getenv("FRAME_START", "1"))
+FRAME_END = int(os.getenv("FRAME_END", "250"))
+
+
+def start_render(blend_file: str, frame_start: int = FRAME_START, frame_end: int = FRAME_END) -> None:
+    exe = Path(BLENDER_EXE)
+    if not exe.exists():
+        raise FileNotFoundError(f"Blender not found: {exe}")
+    output_dir = Path(BLENDER_OUTPUT_DIR)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    args = [str(exe), "-b", blend_file, "-o", str(output_dir / "frame_#####"), "-s", str(frame_start), "-e", str(frame_end), "-a"]
+    proc_store.store.start(RENDER_KEY, args)
+
+
+def stop_render() -> None:
+    proc_store.store.stop(RENDER_KEY)
+
+
+def is_running() -> bool:
+    return proc_store.store.is_running(RENDER_KEY)

--- a/backend/services/mc.py
+++ b/backend/services/mc.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+from ..utils import proc_store
+
+MC_KEY = "minecraft"
+
+MC_JAR_PATH = os.getenv("MC_JAR_PATH", r"C:\\Users\\YoneRai12\\Downloads\\server.jar")
+
+
+def start_server() -> None:
+    jar = Path(MC_JAR_PATH)
+    if not jar.exists():
+        raise FileNotFoundError(f"Minecraft jar not found: {jar}")
+    proc_store.store.start(MC_KEY, ["java", "-jar", str(jar), "nogui"], cwd=jar.parent)
+
+
+def stop_server() -> None:
+    proc_store.store.stop(MC_KEY)
+
+
+def is_running() -> bool:
+    return proc_store.store.is_running(MC_KEY)

--- a/backend/tests/run.sh
+++ b/backend/tests/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+export API_KEY=changeme
+uvicorn backend.main:app --port 8000 &
+PID=$!
+sleep 2
+python backend/tests/test_api.py
+kill $PID

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,21 @@
+import os
+import requests
+
+API_KEY = os.getenv("API_KEY", "changeme")
+BASE_URL = os.getenv("BASE_URL", "http://localhost:8000")
+HEADERS = {"Authorization": f"Bearer {API_KEY}"}
+
+
+def test_status():
+    r = requests.get(f"{BASE_URL}/status", headers=HEADERS)
+    print(r.status_code, r.text)
+
+
+def test_mc_status():
+    r = requests.get(f"{BASE_URL}/mc/status", headers=HEADERS)
+    print(r.status_code, r.text)
+
+
+if __name__ == "__main__":
+    test_status()
+    test_mc_status()

--- a/backend/utils/proc_store.py
+++ b/backend/utils/proc_store.py
@@ -1,0 +1,29 @@
+import subprocess
+from typing import Optional
+
+
+class ProcStore:
+    def __init__(self):
+        self._procs: dict[str, subprocess.Popen] = {}
+
+    def start(self, key: str, args: list[str], cwd: Optional[str] = None) -> None:
+        if key in self._procs:
+            raise RuntimeError(f"Process {key} already running")
+        self._procs[key] = subprocess.Popen(args, cwd=cwd)
+
+    def stop(self, key: str) -> None:
+        proc = self._procs.get(key)
+        if proc and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        self._procs.pop(key, None)
+
+    def is_running(self, key: str) -> bool:
+        proc = self._procs.get(key)
+        return proc is not None and proc.poll() is None
+
+
+store = ProcStore()

--- a/ios-client/ORAControl/Package.swift
+++ b/ios-client/ORAControl/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ORAControl",
+    platforms: [.iOS(.v17)],
+    products: [
+        .library(name: "ORAControl", targets: ["ORAControl"])
+    ],
+    targets: [
+        .target(name: "ORAControl", resources: [.process("Resources")]),
+    ]
+)

--- a/ios-client/ORAControl/README.md
+++ b/ios-client/ORAControl/README.md
@@ -1,0 +1,3 @@
+# ORAControl
+
+SwiftUI app to control ORA Remote backend. Build with Xcode.

--- a/ios-client/ORAControl/Sources/ORAControl/APIClient.swift
+++ b/ios-client/ORAControl/Sources/ORAControl/APIClient.swift
@@ -1,0 +1,59 @@
+import Foundation
+import SwiftUI
+
+class APIClient: ObservableObject {
+    @Published var token: String = KeychainHelper.shared.getToken() ?? "" {
+        didSet { KeychainHelper.shared.saveToken(token) }
+    }
+    var baseURL = URL(string: "http://localhost:8000")!
+
+    private func request(_ path: String, method: String = "GET", body: Data? = nil) async throws -> (Data, URLResponse) {
+        var req = URLRequest(url: baseURL.appendingPathComponent(path))
+        req.httpMethod = method
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let body { req.httpBody = body }
+        return try await URLSession.shared.data(for: req)
+    }
+
+    func status() async throws -> StatusResponse {
+        let (data, _) = try await request("/status")
+        return try JSONDecoder().decode(StatusResponse.self, from: data)
+    }
+
+    func mcStart() async throws { _ = try await request("/mc/start", method: "POST") }
+    func mcStop() async throws { _ = try await request("/mc/stop", method: "POST") }
+    func renderStart(path: String, start: Int, end: Int) async throws {
+        let body = "blend_file=\(path)&frame_start=\(start)&frame_end=\(end)".data(using: .utf8)
+        _ = try await request("/render/start", method: "POST", body: body)
+    }
+    func renderStop() async throws { _ = try await request("/render/stop", method: "POST") }
+}
+
+struct StatusResponse: Codable {
+    let mc_running: Bool
+    let render_running: Bool
+}
+
+class KeychainHelper {
+    static let shared = KeychainHelper()
+    func saveToken(_ token: String) {
+        let data = Data(token.utf8)
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+                                    kSecAttrAccount as String: "apiToken",
+                                    kSecValueData as String: data]
+        SecItemDelete(query as CFDictionary)
+        SecItemAdd(query as CFDictionary, nil)
+    }
+    func getToken() -> String? {
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+                                    kSecAttrAccount as String: "apiToken",
+                                    kSecReturnData as String: true,
+                                    kSecMatchLimit as String: kSecMatchLimitOne]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecSuccess, let data = result as? Data {
+            return String(decoding: data, as: UTF8.self)
+        }
+        return nil
+    }
+}

--- a/ios-client/ORAControl/Sources/ORAControl/DashboardView.swift
+++ b/ios-client/ORAControl/Sources/ORAControl/DashboardView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct DashboardView: View {
+    @EnvironmentObject var api: APIClient
+    @State private var status: StatusResponse?
+    @State private var showingSettings = false
+    @State private var tokenInput = ""
+
+    var body: some View {
+        VStack(spacing: 20) {
+            TextField("Token", text: $api.token)
+                .textFieldStyle(.roundedBorder)
+                .padding()
+            if let status {
+                Text("MC: \(status.mc_running ? "Running" : "Stopped")")
+                Text("Render: \(status.render_running ? "Running" : "Stopped")")
+            }
+            HStack {
+                Button("MC Start") { Task { try? await api.mcStart(); await loadStatus() } }
+                Button("MC Stop") { Task { try? await api.mcStop(); await loadStatus() } }
+            }
+            HStack {
+                Button("Render Start") { showingSettings = true }
+                Button("Render Stop") { Task { try? await api.renderStop(); await loadStatus() } }
+            }
+        }
+        .task { await loadStatus() }
+        .sheet(isPresented: $showingSettings) { RenderSettingsView() }
+    }
+
+    func loadStatus() async {
+        status = try? await api.status()
+    }
+}
+
+struct DashboardView_Previews: PreviewProvider {
+    static var previews: some View {
+        DashboardView().environmentObject(APIClient())
+    }
+}

--- a/ios-client/ORAControl/Sources/ORAControl/ORAControlApp.swift
+++ b/ios-client/ORAControl/Sources/ORAControl/ORAControlApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct ORAControlApp: App {
+    @StateObject private var api = APIClient()
+
+    var body: some Scene {
+        WindowGroup {
+            DashboardView()
+                .environmentObject(api)
+        }
+    }
+}

--- a/ios-client/ORAControl/Sources/ORAControl/RenderSettingsView.swift
+++ b/ios-client/ORAControl/Sources/ORAControl/RenderSettingsView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct RenderSettingsView: View {
+    @EnvironmentObject var api: APIClient
+    @Environment(\.dismiss) var dismiss
+    @State private var path = ""
+    @State private var start = "1"
+    @State private var end = "250"
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Blend File Path", text: $path)
+                TextField("Frame Start", text: $start)
+                    .keyboardType(.numberPad)
+                TextField("Frame End", text: $end)
+                    .keyboardType(.numberPad)
+            }
+            .navigationTitle("Render Settings")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Start") {
+                        Task {
+                            let s = Int(start) ?? 1
+                            let e = Int(end) ?? s
+                            try? await api.renderStart(path: path, start: s, end: e)
+                            dismiss()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct RenderSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        RenderSettingsView().environmentObject(APIClient())
+    }
+}


### PR DESCRIPTION
## Summary
- implement FastAPI backend with bearer token auth
- add services for Minecraft and Blender control
- provide simple test script
- create SwiftUI app template for ORAControl

## Testing
- `python -m py_compile backend/main.py backend/services/mc.py backend/services/blender.py backend/utils/proc_store.py backend/tests/test_api.py`
- `pip install -r backend/requirements.txt`
- `backend/tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68878aadddac832288457bc4d453f5c2