### PR TITLE
Fix Material and Color conditional in chat button

### DIFF
--- a/ios-client/ORAControl/Sources/ORAControl/ContentView.swift
+++ b/ios-client/ORAControl/Sources/ORAControl/ContentView.swift
@@ -190,8 +190,8 @@ private struct InputBar: View {
                     .padding(12)
                     .background(
                         Circle()
-                            .fill(message.isEmpty ? .thinMaterial
-                                                  : Color.accentColor)
+                            .fill(message.isEmpty ? AnyShapeStyle(.thinMaterial)
+                                                  : AnyShapeStyle(Color.accentColor))
                             .matchedGeometryEffect(id: "rightBtn", in: ns)
                     )
             }


### PR DESCRIPTION
## Summary
- fix compile error when mixing `Color` and `Material` in `ContentView`

## Testing
- `pip install -r backend/requirements.txt`
- `bash backend/tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889f8406ea083228388248e5625dc3e